### PR TITLE
Fix ShortUUIDField usage

### DIFF
--- a/paypaladaptive/models.py
+++ b/paypaladaptive/models.py
@@ -30,7 +30,7 @@ class PaypalAdaptive(models.Model):
     money = MoneyField(_(u'money'), max_digits=settings.MAX_DIGITS,
                        decimal_places=settings.DECIMAL_PLACES)
     created_date = models.DateTimeField(_(u'created on'), auto_now_add=True)
-    secret_uuid = ShortUUIDField(_(u'secret UUID'))  # to verify return_url
+    secret_uuid = ShortUUIDField(verbose_name=_(u'secret UUID'))  # to verify return_url
     debug_request = models.TextField(_(u'raw request'), blank=True, null=True)
     debug_response = models.TextField(_(u'raw response'), blank=True,
                                       null=True)


### PR DESCRIPTION
Hi,

I've noticed a bug. Due to uncommon API, the [first argument to `ShortUUIDField`](https://github.com/nebstrebor/django-shortuuidfield/blob/25db3e5/shortuuidfield/fields.py#L15) is `auto`, not `verbose_name`, so the field's initialized incorrectly. The bug isn't normally noticeable, but may break project when `paypaladaptive.models` is imported from some app's `__init__.py` or its immediate dependencies.

Your fork seems to be among the most recent and stable ones, so I thought of submitting a pull request.

Thanks!
